### PR TITLE
numpad and write several bytes by placing a set of bytes

### DIFF
--- a/imgui_hex.cpp
+++ b/imgui_hex.cpp
@@ -548,6 +548,20 @@ bool ImGui::BeginHexEditor(const char* str_id, ImGuiHexEditorState* state, const
 				}
 			}
 		}
+
+		if ( hex_key_pressed == ImGuiKey_None )
+		{
+			int diff = ImGuiKey_Keypad0 - ImGuiKey_0;
+
+			for ( ImGuiKey key = ImGuiKey_Keypad0; key != ImGuiKey_KeypadDecimal; key = (ImGuiKey)( (int)key + 1 ) )
+			{
+				if ( ImGui::IsKeyPressed( key ) )
+				{
+					hex_key_pressed = (ImGuiKey)( key - diff );
+					break;
+				}
+			}
+		}
 	}
 
 	unsigned char stack_line_buf[128];


### PR DESCRIPTION
Add the option to edit bytes via the numpad, which wasn't previously possible.
And change a byte pattern.
"53 BF 67 D6 BF 14 D6"
"53 ?? 67 D6 ?? 14 D6" // doesn't change where the "??"